### PR TITLE
locked github runner version to ubuntu-22.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -28,7 +28,7 @@ jobs:
         run: go test -p 1 -cover -race -v ./...
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ test ]
     steps:
       - name: Checkout


### PR DESCRIPTION
**WHAT**
Locked Github runner to `ubuntu-22.04`

**WHY**
We're using `ubuntu-latest` and this label will become `ubuntu-24`
https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/